### PR TITLE
Hide non-public attributes

### DIFF
--- a/src/MdDocs.ApiReference.Model.Test/CSharpDefinitionFormatterTest.cs
+++ b/src/MdDocs.ApiReference.Model.Test/CSharpDefinitionFormatterTest.cs
@@ -8,25 +8,30 @@ using Mono.Cecil;
 
 namespace Grynwald.MdDocs.ApiReference.Test.Model
 {
+    /// <summary>
+    /// Tests for <see cref="CSharpDefinitionFormatter"/>
+    /// </summary>
     public class CSharpDefinitionFormatterTest : TestBase
     {
         [Theory]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property1), @"public int Property1 { get; set; }")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property2), @"public byte Property2 { get; set; }")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property3), @"public string Property3 { get; }")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property4), @"public string Property4 { get; }")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property5), @"public string Property5 { set; }")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property6), @"public Stream Property6 { get; }")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property7), @"public IEnumerable<string> Property7 { get; }")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Property8), @"public static IEnumerable<string> Property8 { get; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property1), @"public int Property1 { get; set; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property2), @"public byte Property2 { get; set; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property3), @"public string Property3 { get; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property4), @"public string Property4 { get; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property5), @"public string Property5 { set; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property6), @"public Stream Property6 { get; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property7), @"public IEnumerable<string> Property7 { get; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Property8), @"public static IEnumerable<string> Property8 { get; }")]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Property9),
             "[CSharpDefinitionTest1(1)]\r\n" +
             "public static IEnumerable<string> Property9 { get; }")]
-        public void GetDefinition_returns_the_expected_definition_for_properties(string propertyName, string expected)
+        [InlineData(typeof(TestClass_CSharpDefinition_InternalAttribues), nameof(TestClass_CSharpDefinition_InternalAttribues.Property1), @"public string Property1 { get; }")]  // internal attributes must not be included in the definition
+        public void GetDefinition_returns_the_expected_definition_for_properties(Type declaringType, string propertyName, string expected)
         {
             // ARRANGE
-            var propertyDefinition = GetTypeDefinition(typeof(TestClass_CSharpDefinition))
+            var propertyDefinition = GetTypeDefinition(declaringType)
                 .Properties
                 .Single(p => p.Name == propertyName);
 
@@ -38,12 +43,13 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
         }
 
         [Theory]
-        [InlineData(1, @"public int this[object parameter] { get; }")]
-        [InlineData(2, @"public int this[object parameter1, Stream parameter2] { get; }")]
-        public void GetDefinition_returns_the_expected_definition_for_indexers(int parameterCount, string expected)
+        [InlineData(typeof(TestClass_CSharpDefinition), 1, @"public int this[object parameter] { get; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition), 2, @"public int this[object parameter1, Stream parameter2] { get; }")]
+        [InlineData(typeof(TestClass_CSharpDefinition_InternalAttribues), 1, @"public string this[int index] { get; }")] // internal attributes must not be included in the definition
+        public void GetDefinition_returns_the_expected_definition_for_indexers(Type declaringType, int parameterCount, string expected)
         {
             // ARRANGE
-            var propertyDefinition = GetTypeDefinition(typeof(TestClass_CSharpDefinition))
+            var propertyDefinition = GetTypeDefinition(declaringType)
                 .Properties
                 .Single(p => p.Name == "Item" && p.Parameters.Count == parameterCount);
 
@@ -55,19 +61,21 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
         }
 
         [Theory]
-        [InlineData(nameof(TestClass_CSharpDefinition.Field1), @"public string Field1;")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Field2), @"public static string Field2;")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Field3), @"public const string Field3;")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Field4), @"public static readonly int Field4;")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Field1), @"public string Field1;")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Field2), @"public static string Field2;")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Field3), @"public const string Field3;")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Field4), @"public static readonly int Field4;")]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Field5),
             "[CSharpDefinitionTest1(1)]\r\n" +
             "public static readonly int Field5;"
         )]
-        public void GetDefinition_returns_the_expected_definition_for_fields(string fieldName, string expected)
+        [InlineData(typeof(TestClass_CSharpDefinition_InternalAttribues), nameof(TestClass_CSharpDefinition_InternalAttribues.Field1), @"public int Field1;")] // internal attributes must not be included in the definition
+        public void GetDefinition_returns_the_expected_definition_for_fields(Type declaringType, string fieldName, string expected)
         {
             // ARRANGE
-            var fieldDefinition = GetTypeDefinition(typeof(TestClass_CSharpDefinition))
+            var fieldDefinition = GetTypeDefinition(declaringType)
                 .Fields
                 .Single(p => p.Name == fieldName);
 
@@ -79,17 +87,19 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
         }
 
         [Theory]
-        [InlineData(nameof(TestClass_CSharpDefinition.Event1), @"public event EventHandler<EventArgs> Event1;")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Event2), @"public static event EventHandler Event2;")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Event1), @"public event EventHandler<EventArgs> Event1;")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Event2), @"public static event EventHandler Event2;")]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Event3),
             "[CSharpDefinitionTest1(1)]\r\n" +
             "public static event EventHandler Event3;"
         )]
-        public void GetDefinition_returns_the_expected_definition_for_events(string fieldName, string expected)
+        [InlineData(typeof(TestClass_CSharpDefinition_InternalAttribues), nameof(TestClass_CSharpDefinition_InternalAttribues.Event1), @"public static event EventHandler Event1;")]  // internal attributes must not be included in the definition
+        public void GetDefinition_returns_the_expected_definition_for_events(Type declaringType, string fieldName, string expected)
         {
             // ARRANGE
-            var eventDefinition = GetTypeDefinition(typeof(TestClass_CSharpDefinition))
+            var eventDefinition = GetTypeDefinition(declaringType)
                 .Events
                 .Single(p => p.Name == fieldName);
 
@@ -101,55 +111,62 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
         }
 
         [Theory]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method1), @"public void Method1();")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method2), @"public string Method2();")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method3), @"public string Method3(string param1, Stream param2);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method4), @"public static string Method4(string param1, Stream param2);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method5), @"public static string Method5<TParam>(TParam parameter);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method1), @"public void Method1();")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method2), @"public string Method2();")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method3), @"public string Method3(string param1, Stream param2);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method4), @"public static string Method4(string param1, Stream param2);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method5), @"public static string Method5<TParam>(TParam parameter);")]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Method6),
             "[Obsolete]\r\n" +
             "public void Method6();")]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Method7),
             "[Obsolete(\"Use another method\")]\r\n" +
             "public void Method7();")]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Method8),
             "[CSharpDefinitionTest1(1, Property1 = \"Value\")]\r\n" +
             "public void Method8();"
         )]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Method9),
             "[CSharpDefinitionTest2(CSharpDefinitionTestFlagsEnum.Value1 | CSharpDefinitionTestFlagsEnum.Value2)]\r\n" +
             "public void Method9();"
         )]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Method10),
             "[CSharpDefinitionTest3(BindingFlags.NonPublic | BindingFlags.CreateInstance)]\r\n" +
             "public void Method10();"
         )]
         [InlineData(
+            typeof(TestClass_CSharpDefinition),
             nameof(TestClass_CSharpDefinition.Method11),
             "[CSharpDefinitionTest4(CSharpDefinitionTestEnum.Value2)]\r\n" +
             "public void Method11();"
         )]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method12), "public void Method12(ref int value);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method13), "public void Method13(out string value);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method14), "public void Method14(object parameter1, out string value);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method15), "public void Method15(out string[] value);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method16), "public void Method16(in string value);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method17), "public void Method17(string stringParameter = \"default\");")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method18), "public void Method18(string stringParameter = null, int intParameter = 23);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method19), "public void Method19(CSharpDefinitionTestEnum parameter = CSharpDefinitionTestEnum.Value1);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method20), "public void Method20([Optional]string stringParameter);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method21), "public void Method21(string stringParameter = \"default\");")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method22), "public void Method22([CSharpDefinitionTest5]string parameter1);")]
-        [InlineData(nameof(TestClass_CSharpDefinition.Method23), "public void Method23([CSharpDefinitionTest4(CSharpDefinitionTestEnum.Value2)][CSharpDefinitionTest5]string parameter1);")]
-        public void GetDefinition_returns_the_expected_definition_for_methods(string methodName, string expected)
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method12), "public void Method12(ref int value);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method13), "public void Method13(out string value);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method14), "public void Method14(object parameter1, out string value);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method15), "public void Method15(out string[] value);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method16), "public void Method16(in string value);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method17), "public void Method17(string stringParameter = \"default\");")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method18), "public void Method18(string stringParameter = null, int intParameter = 23);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method19), "public void Method19(CSharpDefinitionTestEnum parameter = CSharpDefinitionTestEnum.Value1);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method20), "public void Method20([Optional]string stringParameter);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method21), "public void Method21(string stringParameter = \"default\");")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method22), "public void Method22([CSharpDefinitionTest5]string parameter1);")]
+        [InlineData(typeof(TestClass_CSharpDefinition), nameof(TestClass_CSharpDefinition.Method23), "public void Method23([CSharpDefinitionTest4(CSharpDefinitionTestEnum.Value2)][CSharpDefinitionTest5]string parameter1);")]
+        [InlineData(typeof(TestClass_CSharpDefinition_InternalAttribues), nameof(TestClass_CSharpDefinition_InternalAttribues.Method1), "public void Method1();")]
+        public void GetDefinition_returns_the_expected_definition_for_methods(Type declaringType, string methodName, string expected)
         {
             // ARRANGE
-            var fieldDefinition = GetTypeDefinition(typeof(TestClass_CSharpDefinition))
+            var fieldDefinition = GetTypeDefinition(declaringType)
                 .Methods
                 .Single(p => p.Name == methodName);
 
@@ -299,6 +316,7 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             "[CSharpDefinitionTest6(CSharpDefinitionTestFlagsEnum2.Value1 | CSharpDefinitionTestFlagsEnum2.Value2)]\r\n" +
             "public class CSharpDefinitionTest_ClassWithAttribute3"
         )]
+        [InlineData(nameof(TestClass_CSharpDefinition_InternalAttribues), "public class TestClass_CSharpDefinition_InternalAttribues")]
         public void GetDefinition_returns_the_expected_definition_for_types(string typeName, string expected)
         {
             // ARRANGE

--- a/src/MdDocs.ApiReference.Model.Test/ModuleDocumentationTest.cs
+++ b/src/MdDocs.ApiReference.Model.Test/ModuleDocumentationTest.cs
@@ -95,7 +95,8 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
                 typeof(TestClass_CSharpDefinition_NestedTypes.TestClass_CSharpDefinition_NestedClass4<>.NestedClass5),
                 typeof(TestClass_CSharpDefinition_NestedTypes.NestedClass6<,>),
                 typeof(TestClass_CSharpDefinition_NestedTypes.NestedClass6<,>.NestedClass7<>),
-                typeof(TestClass_CSharpDefinition_InternalAttribues)
+                typeof(TestClass_CSharpDefinition_InternalAttribues),
+                typeof(TestClass_Attributes_Internal)
             })
             .Distinct()
             .Select(GetTypeDefinition)

--- a/src/MdDocs.ApiReference.Model.Test/ModuleDocumentationTest.cs
+++ b/src/MdDocs.ApiReference.Model.Test/ModuleDocumentationTest.cs
@@ -95,6 +95,7 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
                 typeof(TestClass_CSharpDefinition_NestedTypes.TestClass_CSharpDefinition_NestedClass4<>.NestedClass5),
                 typeof(TestClass_CSharpDefinition_NestedTypes.NestedClass6<,>),
                 typeof(TestClass_CSharpDefinition_NestedTypes.NestedClass6<,>.NestedClass7<>),
+                typeof(TestClass_CSharpDefinition_InternalAttribues)
             })
             .Distinct()
             .Select(GetTypeDefinition)

--- a/src/MdDocs.ApiReference.Model.Test/TypeDocumentationTest.cs
+++ b/src/MdDocs.ApiReference.Model.Test/TypeDocumentationTest.cs
@@ -465,6 +465,26 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             Assert.True(expectedAttributes.SequenceEqual(sut.Attributes));
         }
 
+        [Theory]
+        [InlineData(typeof(TestClass_Attributes_Internal))]
+        public void Attributes_does_not_include_internal_attributes(Type type)
+        {
+            // ARRANGE
+            var expectedAttributes = new[]
+            {                
+                new SimpleTypeId("Grynwald.MdDocs.ApiReference.Test.TestData", "TestAttribute")
+            };
+
+            // ACT
+            var sut = GetTypeDocumentation(type);
+
+            // ASSERT
+            Assert.NotNull(sut.Attributes);
+            Assert.Equal(expectedAttributes.Length, sut.Attributes.Count);
+            Assert.True(expectedAttributes.SequenceEqual(sut.Attributes));
+        }
+
+
         [Fact]
         public void TryGetDocumentation_returns_null_for_an_undocumented_type()
         {

--- a/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableEventId.cs
+++ b/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableEventId.cs
@@ -38,6 +38,6 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             info.AddValue(nameof(EventId.Name), EventId.Name);
         }
 
-        public static implicit operator EventId(XunitSerializableEventId serializable) => serializable?.EventId ?? throw new InvalidOperationException();
+        public static implicit operator EventId(XunitSerializableEventId serializable) => serializable?.EventId!;
     }
 }

--- a/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableFieldId.cs
+++ b/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableFieldId.cs
@@ -38,6 +38,6 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             info.AddValue(nameof(FieldId.Name), FieldId.Name);
         }
 
-        public static implicit operator FieldId(XunitSerializableFieldId serializable) => serializable?.FieldId ?? throw new InvalidOperationException();
+        public static implicit operator FieldId(XunitSerializableFieldId serializable) => serializable?.FieldId!;
     }
 }

--- a/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableMemberId.cs
+++ b/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableMemberId.cs
@@ -98,6 +98,6 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             }
         }
 
-        public static implicit operator MemberId(XunitSerializableMemberId serializable) => serializable?.MemberId ?? throw new InvalidOperationException();
+        public static implicit operator MemberId(XunitSerializableMemberId serializable) => serializable?.MemberId!;
     }
 }

--- a/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableMethodId.cs
+++ b/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableMethodId.cs
@@ -66,6 +66,6 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             }
         }
 
-        public static implicit operator MethodId(XunitSerializableMethodId serializable) => serializable?.MethodId ?? throw new InvalidOperationException();
+        public static implicit operator MethodId(XunitSerializableMethodId serializable) => serializable?.MethodId!;
     }
 }

--- a/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableNamespaceId.cs
+++ b/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableNamespaceId.cs
@@ -36,6 +36,6 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             info.AddValue(nameof(NamespaceId.Name), NamespaceId.Name);
         }
 
-        public static implicit operator NamespaceId(XunitSerializableNamespaceId serializable) => serializable?.NamespaceId ?? throw new InvalidOperationException();
+        public static implicit operator NamespaceId(XunitSerializableNamespaceId serializable) => serializable?.NamespaceId!;
     }
 }

--- a/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializablePropertyId.cs
+++ b/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializablePropertyId.cs
@@ -54,7 +54,6 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             }
         }
 
-        public static implicit operator PropertyId(XunitSerializablePropertyId serializable) =>
-            serializable?.PropertyId ?? throw new InvalidOperationException();
+        public static implicit operator PropertyId(XunitSerializablePropertyId serializable) => serializable?.PropertyId!;
     }
 }

--- a/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableTypeId.cs
+++ b/src/MdDocs.ApiReference.Model.Test/_Helpers/XunitSerializableTypeId.cs
@@ -143,7 +143,6 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
             }
         }
 
-        public static implicit operator TypeId(XunitSerializableTypeId serializable) =>
-            serializable?.TypeId ?? throw new InvalidOperationException();
+        public static implicit operator TypeId(XunitSerializableTypeId serializable) => serializable?.TypeId!;
     }
 }

--- a/src/MdDocs.ApiReference.Model/_Extensions/EventDefinitionExtensions.cs
+++ b/src/MdDocs.ApiReference.Model/_Extensions/EventDefinitionExtensions.cs
@@ -4,26 +4,22 @@ using Mono.Cecil;
 
 namespace Grynwald.MdDocs.ApiReference.Model
 {
-    internal static class MethodDefinitionExtensions
+    public static class EventDefinitionExtensions
     {
         /// <summary>
-        /// Gets a methods's public custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
+        /// Gets a events's public custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
         /// </summary>
         /// <returns>
         /// Returns all attributes except:
-        /// <list type="bullet">
-        ///     <item><c>ExtensionAttribute</c> </item>
+        /// <list type="bullet">        
         ///     <item>non-public Attribute types</item>
         /// </list>
         /// </returns>
-        public static IEnumerable<CustomAttribute> GetCustomAttributes(this MethodDefinition parameter)
+        public static IEnumerable<CustomAttribute> GetCustomAttributes(this EventDefinition parameter)
         {
             return parameter.CustomAttributes
                 .Where(attribute =>
                 {
-                    if (attribute.AttributeType.FullName == Constants.ExtensionAttributeFullName)
-                        return false;
-
                     if (!attribute.AttributeType.Resolve().IsPublic)
                         return false;
 

--- a/src/MdDocs.ApiReference.Model/_Extensions/FieldDefinitionExtensions.cs
+++ b/src/MdDocs.ApiReference.Model/_Extensions/FieldDefinitionExtensions.cs
@@ -4,26 +4,22 @@ using Mono.Cecil;
 
 namespace Grynwald.MdDocs.ApiReference.Model
 {
-    internal static class MethodDefinitionExtensions
+    public static class FieldDefinitionExtensions
     {
         /// <summary>
-        /// Gets a methods's public custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
+        /// Gets a fields's public custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
         /// </summary>
         /// <returns>
         /// Returns all attributes except:
-        /// <list type="bullet">
-        ///     <item><c>ExtensionAttribute</c> </item>
+        /// <list type="bullet">        
         ///     <item>non-public Attribute types</item>
         /// </list>
         /// </returns>
-        public static IEnumerable<CustomAttribute> GetCustomAttributes(this MethodDefinition parameter)
+        public static IEnumerable<CustomAttribute> GetCustomAttributes(this FieldDefinition parameter)
         {
             return parameter.CustomAttributes
                 .Where(attribute =>
                 {
-                    if (attribute.AttributeType.FullName == Constants.ExtensionAttributeFullName)
-                        return false;
-
                     if (!attribute.AttributeType.Resolve().IsPublic)
                         return false;
 

--- a/src/MdDocs.ApiReference.Model/_Extensions/ParameterDefinitionExtensions.cs
+++ b/src/MdDocs.ApiReference.Model/_Extensions/ParameterDefinitionExtensions.cs
@@ -13,6 +13,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
         /// Returns all attributes except:
         /// <list type="bullet">
         ///     <item><c>IsReadOnlyAttribute</c> </item>
+        ///     <item>non-public Attribute types</item>
         /// </list>
         /// </returns>
         public static IEnumerable<CustomAttribute> GetCustomAttributes(this ParameterDefinition parameter)
@@ -21,6 +22,9 @@ namespace Grynwald.MdDocs.ApiReference.Model
                 .Where(attribute =>
                 {
                     if (attribute.AttributeType.FullName == Constants.IsReadOnlyAttributeFullName)
+                        return false;
+
+                    if (!attribute.AttributeType.Resolve().IsPublic)
                         return false;
 
                     return true;

--- a/src/MdDocs.ApiReference.Model/_Extensions/PropertyDefinitionExtensions.cs
+++ b/src/MdDocs.ApiReference.Model/_Extensions/PropertyDefinitionExtensions.cs
@@ -4,26 +4,22 @@ using Mono.Cecil;
 
 namespace Grynwald.MdDocs.ApiReference.Model
 {
-    internal static class MethodDefinitionExtensions
+    public static class PropertyDefinitionExtensions
     {
         /// <summary>
-        /// Gets a methods's public custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
+        /// Gets a property's public custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
         /// </summary>
         /// <returns>
         /// Returns all attributes except:
-        /// <list type="bullet">
-        ///     <item><c>ExtensionAttribute</c> </item>
+        /// <list type="bullet">        
         ///     <item>non-public Attribute types</item>
         /// </list>
         /// </returns>
-        public static IEnumerable<CustomAttribute> GetCustomAttributes(this MethodDefinition parameter)
+        public static IEnumerable<CustomAttribute> GetCustomAttributes(this PropertyDefinition parameter)
         {
             return parameter.CustomAttributes
                 .Where(attribute =>
                 {
-                    if (attribute.AttributeType.FullName == Constants.ExtensionAttributeFullName)
-                        return false;
-
                     if (!attribute.AttributeType.Resolve().IsPublic)
                         return false;
 

--- a/src/MdDocs.ApiReference.Model/_Extensions/TypeDefinitionExtensions.cs
+++ b/src/MdDocs.ApiReference.Model/_Extensions/TypeDefinitionExtensions.cs
@@ -80,7 +80,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
         }
 
         /// <summary>
-        /// Gets a type's custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
+        /// Gets a type's public custom attributes excluding attributes emitted by the C# compiler not relevant for the user.
         /// </summary>
         /// <returns>
         /// Returns all attributes except:
@@ -88,6 +88,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
         ///     <item><c>DefaultMemberAttribute</c> for classes.</item>
         ///     <item><c>ExtensionAttribute</c> (indicating that the class defines extension methods) for classes.</item>
         ///     <item><c>IsReadOnlyAttribute</c> for structs indicating that it is a <c>readonly struct</c>.</item>
+        ///     <item>non-public Attribute types</item>
         /// </list>
         /// </returns>
         public static IEnumerable<CustomAttribute> GetCustomAttributes(this TypeDefinition type)
@@ -105,6 +106,10 @@ namespace Grynwald.MdDocs.ApiReference.Model
 
                     if (typeKind == TypeKind.Struct && attribute.AttributeType.FullName == Constants.IsReadOnlyAttributeFullName)
                         return false;
+
+                    if (!attribute.AttributeType.Resolve().IsPublic)
+                        return false;
+
 
                     return true;
                 });

--- a/src/MdDocs.ApiReference.Model/_Helpers/CSharpDefinitionFormatter.cs
+++ b/src/MdDocs.ApiReference.Model/_Helpers/CSharpDefinitionFormatter.cs
@@ -360,7 +360,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
 
         private static void AppendCustomAttributes(StringBuilder definitionBuilder, IEnumerable<CustomAttribute> customAttributes, bool singleLine = false)
         {
-            foreach (var attribute in customAttributes)
+            foreach (var attribute in customAttributes.Where(a => a.AttributeType.Resolve().IsPublic))
             {
                 var attributeName = GetDisplayName(attribute.AttributeType);
 

--- a/src/MdDocs.ApiReference.Model/_Helpers/CSharpDefinitionFormatter.cs
+++ b/src/MdDocs.ApiReference.Model/_Helpers/CSharpDefinitionFormatter.cs
@@ -26,7 +26,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
         {
             var definitionBuilder = new StringBuilder();
 
-            AppendCustomAttributes(definitionBuilder, property.CustomAttributes);
+            AppendCustomAttributes(definitionBuilder, property.GetCustomAttributes());
 
             // "public"
             definitionBuilder.Append("public ");
@@ -90,7 +90,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
         {
             var definitionBuilder = new StringBuilder();
 
-            AppendCustomAttributes(definitionBuilder, field.CustomAttributes);
+            AppendCustomAttributes(definitionBuilder, field.GetCustomAttributes());
 
             // "public"
             if (field.IsPublic)
@@ -162,9 +162,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
                     // remove number of type parameters from type name
                     methodName = methodName.Substring(0, methodName.LastIndexOf("`"));
                 }
-
-                //TODO: Support for nested types
-
+                
                 definitionBuilder.Append(methodName);
             }
             // non-constructor method
@@ -249,7 +247,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
         {
             var definitionBuilder = new StringBuilder();
 
-            AppendCustomAttributes(definitionBuilder, @event.CustomAttributes);
+            AppendCustomAttributes(definitionBuilder, @event.GetCustomAttributes());
 
             // "public"
             if (@event.AddMethod?.IsPublic == true || @event.RemoveMethod?.IsPublic == true)
@@ -360,7 +358,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
 
         private static void AppendCustomAttributes(StringBuilder definitionBuilder, IEnumerable<CustomAttribute> customAttributes, bool singleLine = false)
         {
-            foreach (var attribute in customAttributes.Where(a => a.AttributeType.Resolve().IsPublic))
+            foreach (var attribute in customAttributes)
             {
                 var attributeName = GetDisplayName(attribute.AttributeType);
 

--- a/src/MdDocs.ApiReference.Test.TestData/Grynwald.MdDocs.ApiReference.Test.TestData.xml
+++ b/src/MdDocs.ApiReference.Test.TestData/Grynwald.MdDocs.ApiReference.Test.TestData.xml
@@ -14,6 +14,11 @@
             TestClass for attributes
             </summary>
         </member>
+        <member name="T:Grynwald.MdDocs.ApiReference.Test.TestData.TestClass_Attributes_Internal">
+            <summary>
+            TestClass for internal attributes
+            </summary>
+        </member>
         <member name="T:Grynwald.MdDocs.ApiReference.Test.TestData.TestClass_Constructors">
             <summary>
             Test class for constructors

--- a/src/MdDocs.ApiReference.Test.TestData/TestClass_Attributes_Internal.cs
+++ b/src/MdDocs.ApiReference.Test.TestData/TestClass_Attributes_Internal.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Grynwald.MdDocs.ApiReference.Test.TestData
+{
+    internal class TestAttribute_Internal : Attribute
+    {
+    }
+
+    /// <summary>
+    /// TestClass for internal attributes
+    /// </summary>
+    [TestAttribute]
+    [TestAttribute_Internal]
+    public class TestClass_Attributes_Internal
+    {        
+    }
+}

--- a/src/MdDocs.ApiReference.Test.TestData/TestData_CSharpDefinitionFormatter.cs
+++ b/src/MdDocs.ApiReference.Test.TestData/TestData_CSharpDefinitionFormatter.cs
@@ -340,4 +340,28 @@ namespace Grynwald.MdDocs.ApiReference.Test.TestData
             { }
         }
     }
+
+    internal class TestClass_CSharpDefinition_InternalTestAttribute : Attribute
+    { }
+
+    [TestClass_CSharpDefinition_InternalTest]
+    public class TestClass_CSharpDefinition_InternalAttribues
+    {
+        [TestClass_CSharpDefinition_InternalTest]
+        public string Property1 { get; }
+
+        [TestClass_CSharpDefinition_InternalTest]
+        public string this[int index] => throw new NotImplementedException();
+
+
+        [TestClass_CSharpDefinition_InternalTest]
+        public int Field1;
+
+        [TestClass_CSharpDefinition_InternalTest]
+        public static event EventHandler Event1;
+
+        [TestClass_CSharpDefinition_InternalTest]
+        public void Method1() => throw new NotImplementedException();
+    }
+
 }


### PR DESCRIPTION
Exclude custom attributes from documentation unless their type is public