### PR TITLE
fix: Fix FileNotFoundException in MSBuild tasks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/utilities"]
+	path = deps/utilities
+	url = https://github.com/ap0llo/utilities.git

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ corresponding sub-pages:
 
 ## Building from source
 
-MdDocs is a .NET Core application and can be built using the .NET SDK 3.1
+ℹ This repository uses git submodules. Use `git clone --recursive` to check out submodules as well.
+
+MdDocs is a .NET Core application and can be built using the .NET SDK 3.1 (see [global.json](./global.json))
 
 ```ps1
 dotnet restore .\src\MdDocs.sln
@@ -41,6 +43,13 @@ dotnet restore .\src\MdDocs.sln
 dotnet build .\src\MdDocs.sln
 
 dotnet pack .\src\MdDocs.sln
+```
+
+To run tests, the .NET SK 2.1 (version 2.1.800) and a installation of Visual Studio 2019 is requried as well.
+(this only applies to the `MdDocs.MSBuild.IntegrationTest` project, all other test project should be executable with only the .NET Core 3.1 SDK).
+
+```ps1
+dotnet test .\src\MdDocs.sln
 ```
 
 ## Issues
@@ -64,12 +73,17 @@ created by me without anyone else being involved in the discussion.
 - [CommandLineParser](https://github.com/gsscoder/commandline)
 - [Nerdbank.GitVersioning](https://github.com/AArnott/Nerdbank.GitVersioning/)
 - [Microsoft.Extensions.Logging](https://github.com/aspnet/Extensions)
+- [Microsoft.Extensions.Configuration](https://github.com/aspnet/Extensions)
 - [Microsoft.DotNet.Analyzers.Compatibility](https://github.com/dotnet/platform-compat)
 - [xUnit](http://xunit.github.io/)
 - [Xunit.Combinatorial](https://github.com/AArnott/Xunit.Combinatorial)
 - [Moq](https://github.com/moq/moq4)
 - [ApprovalTests](https://github.com/approvals/ApprovalTests.Net)
 - [Microsoft.CodeAnalysis.CSharp](https://github.com/dotnet/roslyn)
+- [Coverlet](https://github.com/tonerdo/coverlet)
+- [MSBuild](https://github.com/dotnet/msbuild/)
+- [SourceLink](https://github.com/dotnet/sourcelink)
+- [NuGet](https://github.com/NuGet/NuGet.Client)
 
 ## Versioning and Branching
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ trigger:
 
 pr:
   - master
-  - releases/*
+  - release/*
 
 variables:
   # Build settings

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,9 @@ jobs:
     vmImage: $(azuredevops_vmimage)
   steps:
 
+  - checkout: self
+    submodules: true
+
   # Install .NET Core SDK and runtime (version specified in global.json)
   - task: UseDotNet@2
     displayName: ⚙ Install .NET Core SDK

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,6 @@ variables:
   nuget_org_PackageName: 'Grynwald.MdDocs'                  # the name of the package being published
 
   # GitHub settings
-  github_createRelease: true                          # enable creation of GitHub releases when a package was uploaded to NuGet.org
   github_ServiceConnectionName: 'GitHub: ap0llo'      # the name of the Azure DevOps service connection to use for creating GitHub releases
   github_repositoryName: 'ap0llo/mddocs'              # the name of the github repo to create the release in
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,12 +124,15 @@ jobs:
       failIfCoverageEmpty: true
 
   # Create NuGet Package and  publish as build artifact
-  - task: DotNetCoreCLI@2
+  - task: CmdLine@2
     displayName: 📦 Pack NuGet package
     inputs:
-      command: pack
-      projects: $(solutionPath)
-      arguments: '--configuration $(configuration) --output $(Build.ArtifactStagingDirectory) --no-build /warnaserror'
+      script: >-
+        dotnet pack $(solutionPath) 
+        --configuration $(configuration) 
+        --output $(Build.ArtifactStagingDirectory) 
+        --no-build 
+        /warnaserror        
   - task: PublishBuildArtifacts@1
     displayName: '📤 Publish Artifacts: $(artifactsName_Binaries)'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,12 +46,16 @@ variables:
   github_ServiceConnectionName: 'GitHub: ap0llo'      # the name of the Azure DevOps service connection to use for creating GitHub releases
   github_repositoryName: 'ap0llo/mddocs'              # the name of the github repo to create the release in
 
+  # Azure DevOps agent settings
+  azuredevops_vmimage: windows-latest
+
 jobs:
 
 # Main Build and test job: Builds the projects and runs all tests
 - job: Build_and_Test
   displayName: 🛠 Build and Test
-  pool: Hosted VS2017
+  pool: 
+    vmImage: $(azuredevops_vmimage)
   steps:
 
   # Install .NET Core SDK and runtime (version specified in global.json)
@@ -153,7 +157,8 @@ jobs:
 # Job to push package to MyGet.org after build
 - job: Publish_to_MyGet
   displayName: 🚚 Publish to MyGet
-  pool: Hosted VS2017
+  pool: 
+    vmImage: $(azuredevops_vmimage)
   # Only run after main build job and only if the current branch is master or a release branch
   dependsOn: Build_and_Test
   condition: and(succeeded('Build_and_Test'), or(eq(variables['build.sourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') ))
@@ -177,7 +182,8 @@ jobs:
 # Job to push package to NuGet.org after build (only for builds of release branches)
 - job: Publish_to_NuGet_org
   displayName: 🚚 Publish to NuGet.org
-  pool: Hosted VS2017
+  pool: 
+    vmImage: $(azuredevops_vmimage)
   # Only run after main build job and only if the current branch is a release branch
   dependsOn: Build_and_Test
   condition: |
@@ -206,7 +212,8 @@ jobs:
 # Job to create a GitHub release (only if a package was uploaded to NuGet.org)
 - job: Create_GitHub_Release
   displayName: 🔖 Create GitHub Release
-  pool: Hosted VS2017
+  pool: 
+    vmImage: $(azuredevops_vmimage)
   # Only run if build was successful and a package was uploaded to nuget.org
   dependsOn:
   - Build_and_Test
@@ -273,7 +280,8 @@ jobs:
 # Job to create a GitHub *DRAFT* release (only if a package was uploaded to myget.org)
 - job: Create_GitHub_Draft_Release
   displayName: 🔖 Create GitHub DRAFT Release
-  pool: Hosted VS2017
+  pool: 
+    vmImage: $(azuredevops_vmimage)
   # Only run if build was successful and a package was uploaded to nuget.org
   dependsOn:
   - Build_and_Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,13 @@ jobs:
       packageType: sdk
       useGlobalJson: true
 
+  # Also install .NET Core 2.1 SDK because MSBuild integration tests run with both .NET Core 3.1 and 2.1
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 2.1 SDK'
+    inputs:
+      packageType: sdk
+      version: 2.1.809
+
   # Restore local .NET Core tools
   - task: DotNetCoreCLI@2
     displayName: 📥 Restore local tools

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -32,28 +32,6 @@
 
     </Target>
     
-    <UsingTask TaskName="FixModifiedTime"
-               TaskFactory="RoslynCodeTaskFactory"
-                AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
-        <ParameterGroup>
-            <Directory Required="true" />
-        </ParameterGroup>
-        <Task>
-            <Using Namespace="System.IO" />
-            <Code Type="Fragment" Language="cs">
-                <![CDATA[
-                    var dir = new DirectoryInfo(Directory);
-                    foreach(var file in dir.EnumerateFiles()) 
-                    {
-                        if(file.Name.StartsWith("Microsoft.Extensions.") && file.LastWriteTime.Year == 1980) 
-                        {
-                                file.LastWriteTime = file.CreationTime;
-                        }
-                    }
-                ]]>
-            </Code>
-        </Task>
-    </UsingTask>
 
     <!-- 
         Some projects reference Microsoft.Extensions.* packages in version 3.1.0 
@@ -68,10 +46,40 @@
         3.1.0 because later versions cause file load errros when loaded by MSBuild breaking the MSBuild tasks
         https://github.com/ap0llo/mddocs/issues/75
     -->
-    <Target Name="FixFileTimestamps" AfterTargets="AfterBuild">
-        <Message Importance="high" Text="Fixing timestamps in $(OutputPath)" />
-        <FixModifiedTime Directory="$(OutputPath)" />
+    <Target Name="FixFileTimestampsInOutputPath" AfterTargets="AfterBuild">
+        <ItemGroup>
+            <_FixModifiedFile Include="$(OutputPath)/Microsoft.Extensions*" />
+        </ItemGroup>
+        <FixModifiedTime Files="@(_FixModifiedFile)" />
     </Target>
 
+    <Target Name="FixFileTimestampsOnPackageFiles" BeforeTargets="GenerateNuspec">
+        <FixModifiedTime Files="@(_PackageFiles)" />
+    </Target>
+
+    <UsingTask TaskName="FixModifiedTime"
+               TaskFactory="RoslynCodeTaskFactory"
+                AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+        <ParameterGroup>
+            <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System.IO" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                    foreach(var fileItem in Files) 
+                    {
+                        var fullPath = fileItem.GetMetadata("FullPath");
+                        var fileInfo = new FileInfo(fullPath);
+                        if(fileInfo.LastWriteTime.Year == 1980) 
+                        {
+                            Log.LogMessage($"Fixing timestamp of file '{fullPath}'");
+                            fileInfo.LastWriteTime = fileInfo.CreationTime;
+                        }
+                    }
+                ]]>
+            </Code>
+        </Task>
+    </UsingTask>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -31,6 +31,47 @@
         </ItemGroup>
 
     </Target>
+    
+    <UsingTask TaskName="FixModifiedTime"
+               TaskFactory="RoslynCodeTaskFactory"
+                AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+        <ParameterGroup>
+            <Directory Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System.IO" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+         var dir = new DirectoryInfo(Directory);
+         foreach(var file in dir.EnumerateFiles()) 
+         {
+           if(file.LastWriteTime.Year == 1980) 
+           {
+                file.LastWriteTime = file.CreationTime;
+           }
+         }
+      ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+
+    <!-- 
+        Some projects reference Microsoft.Extensions.* packages in version 3.1.0 
+        which shipped with broken timestamps for the files in the NuGet package
+        (see https://github.com/dotnet/extensions/issues/2750).
+
+        This makes it impossible to repack the files in a NuGet package 
+        (which is required for both tools packages as well as the MSBuild package).
+        To work around this, set a valid "modified" date on all assemblies in the output.
+
+        Note: Package versions after 3.1.0 fix this issue, but we need to reference
+        3.1.0 because later versions cause file load errros when loaded by MSBuild breaking the MSBuild tasks
+        https://github.com/ap0llo/mddocs/issues/75
+    -->
+    <Target Name="FixFileTimestamps" AfterTargets="AfterBuild">
+        <Message Importance="high" Text="Fixing timestamps in $(OutputPath)" />
+        <FixModifiedTime Directory="$(OutputPath)" />
+    </Target>
 
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -42,15 +42,15 @@
             <Using Namespace="System.IO" />
             <Code Type="Fragment" Language="cs">
                 <![CDATA[
-         var dir = new DirectoryInfo(Directory);
-         foreach(var file in dir.EnumerateFiles()) 
-         {
-           if(file.LastWriteTime.Year == 1980) 
-           {
-                file.LastWriteTime = file.CreationTime;
-           }
-         }
-      ]]>
+                    var dir = new DirectoryInfo(Directory);
+                    foreach(var file in dir.EnumerateFiles()) 
+                    {
+                        if(file.Name.StartsWith("Microsoft.Extensions.") && file.LastWriteTime.Year == 1980) 
+                        {
+                                file.LastWriteTime = file.CreationTime;
+                        }
+                    }
+                ]]>
             </Code>
         </Task>
     </UsingTask>

--- a/src/MdDocs.Common/Grynwald.MdDocs.Common.csproj
+++ b/src/MdDocs.Common/Grynwald.MdDocs.Common.csproj
@@ -15,9 +15,18 @@
     <PackageReference Include="Grynwald.MarkdownGenerator" Version="2.5.34" />
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
+
+    <!--
+      Important: Keep version at 3.1.0, do not upgrade to newer versions of the 3.1.* line.
+      Using later versions causes assembly load errors when MSBuild attemps to load the assemblies.
+      https://github.com/ap0llo/mddocs/issues/75
+
+      The preview version 5 of these packages does not seem to have this issue,
+      so this should be revisited after the relesae of .NET 5
+    -->
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
   </ItemGroup>
 
 

--- a/src/MdDocs.Common/Grynwald.MdDocs.Common.csproj
+++ b/src/MdDocs.Common/Grynwald.MdDocs.Common.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grynwald.Utilities.Configuration" Version="1.6.11-pre" />
     <PackageReference Include="Grynwald.MarkdownGenerator" Version="2.5.34" />
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.7" />
@@ -41,6 +40,20 @@
     
   <ItemGroup>
     <Compile Include="../shared/Nullable.cs" />
+  </ItemGroup>
+  
+  <!--
+    Include Grynwald.Utilities.Configuration as source instead of using the NuGet package.
+    
+    Utilities.Configuration depends on a different version of Microsoft.Extensions.Configuration than this project.
+    Because Microsoft.Extension.Configuration assemblies are strong-named, this can lead to assembly load errors
+    on .NET Framework. Usually this can be solved using assembly binding redirects, however through MdDocs.MSBuild, 
+    the assemblies are loaded into a process for which the binding redirects cannot be changed (MSBuild).
+    To resolve this, the library is included as source, making it possible to build 
+    everything against the same version of Microsoft.Extensions.Configuration.
+  -->
+  <ItemGroup>
+    <Compile Include="..\..\deps\utilities\src\Utilities.Configuration\**\*.cs" />
   </ItemGroup>
     
 </Project>

--- a/src/MdDocs.MSBuild.IntegrationTest/Grynwald.MdDocs.MSBuild.IntegrationTest.csproj
+++ b/src/MdDocs.MSBuild.IntegrationTest/Grynwald.MdDocs.MSBuild.IntegrationTest.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.0.1" />
+        <PackageReference Include="NuGet.Packaging" Version="5.7.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\MdDocs.MSBuild\Grynwald.MdDocs.MSBuild.csproj" />
+    </ItemGroup>
+
+    <Target Name="BuildPackageToTestOutput" AfterTargets="Build">
+
+        <RemoveDir Directories="$(OutputPath)/packages/" />
+        
+        <MSBuild Projects="..\MdDocs.MSBuild\Grynwald.MdDocs.MSBuild.csproj" Properties="PackageOutputPath=$(OutputPath)/packages/" Targets="Build;Pack" />
+    </Target>
+
+</Project>

--- a/src/MdDocs.MSBuild.IntegrationTest/Grynwald.MdDocs.MSBuild.IntegrationTest.csproj
+++ b/src/MdDocs.MSBuild.IntegrationTest/Grynwald.MdDocs.MSBuild.IntegrationTest.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/MdDocs.MSBuild.IntegrationTest/Grynwald.MdDocs.MSBuild.IntegrationTest.csproj
+++ b/src/MdDocs.MSBuild.IntegrationTest/Grynwald.MdDocs.MSBuild.IntegrationTest.csproj
@@ -12,6 +12,8 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
         <PackageReference Include="NuGet.Packaging" Version="5.7.0" />
+        <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MdDocs.MSBuild.IntegrationTest/MSBuildIntegrationTest.cs
+++ b/src/MdDocs.MSBuild.IntegrationTest/MSBuildIntegrationTest.cs
@@ -155,6 +155,19 @@ namespace Grynwald.MdDocs.MSBuild.IntegrationTest
                 RedirectStandardError = true
             };
 
+            // The build process inherits the environment variables of the test process.
+            // Because the test process is itself running on .NET,
+            // some of the inherited environment varibales cause errors,
+            // especially when the test uses a different .NET Core SDK than the test process.
+            // To avoid these errors, remove environment variables that are not set
+            // when a process is started from the commandline from the child process.
+            startInfo.EnvironmentVariables.Remove("DOTNET_CLI_TELEMETRY_SESSIONID");
+            startInfo.EnvironmentVariables.Remove("DOTNET_HOST_PATH");
+            startInfo.EnvironmentVariables.Remove("MSBUILDENSURESTDOUTFORTASKPROCESSES");
+            startInfo.EnvironmentVariables.Remove("MSBuildExtensionsPath");
+            startInfo.EnvironmentVariables.Remove("MSBuildLoadMicrosoftTargetsReadOnly");
+            startInfo.EnvironmentVariables.Remove("MSBuildSDKsPath");
+
             var process = Process.Start(startInfo);
 
             process.OutputDataReceived += (s, e) => m_OutputHelper.WriteLine(e?.Data ?? "");

--- a/src/MdDocs.MSBuild.IntegrationTest/MSBuildIntegrationTest.cs
+++ b/src/MdDocs.MSBuild.IntegrationTest/MSBuildIntegrationTest.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Grynwald.Utilities.IO;
+using NuGet.Common;
+using NuGet.Packaging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Grynwald.MdDocs.MSBuild.IntegrationTest
+{
+
+
+    public class MSBuildIntegrationTest : IDisposable
+    {
+        private readonly TemporaryDirectory m_WorkingDirectory = new TemporaryDirectory();
+        private readonly ITestOutputHelper m_OutputHelper;
+
+        public MSBuildIntegrationTest(ITestOutputHelper outputHelper)
+        {
+            m_OutputHelper = outputHelper;
+        }
+
+
+        public void Dispose() => m_WorkingDirectory.Dispose();
+
+
+        private static IEnumerable<MSBuildRuntimeInfo> MSBuildRuntimes
+        {
+            get
+            {
+                yield return new MSBuildRuntimeInfo(MSBuildRuntimeType.Core, Version.Parse("3.1.100"));
+                yield return new MSBuildRuntimeInfo(MSBuildRuntimeType.Core, Version.Parse("2.1.800"));
+                yield return new MSBuildRuntimeInfo(MSBuildRuntimeType.Full, Version.Parse("16.0"));
+            }
+        }
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            object[] TestCase(MSBuildRuntimeInfo runtime, string msbuildArgs, string[] expectedFiles)
+            {
+                return new object[] { runtime, msbuildArgs, expectedFiles };
+            }
+
+            var apiReferenceExpectedFiles = new[]
+            {
+                "api/MyNamespace/index.md",
+                "api/MyNamespace/Class1/index.md",
+                "api/MyNamespace/Class1/constructors/index.md"
+            };
+
+            var commandlineHelpExpectedFiles = new[]
+            {
+                "commandlinehelp/index.md"
+            };
+
+            foreach (var runtime in MSBuildRuntimes)
+            {
+                yield return TestCase(runtime, "/p:GenerateApiReferenceDocumentationOnBuild=true", apiReferenceExpectedFiles);
+                yield return TestCase(runtime, "/p:GenerateCommandLineDocumentationOnBuild=true", commandlineHelpExpectedFiles);
+            }
+        }
+
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void Documentation_is_generated_during_build(MSBuildRuntimeInfo runtime, string msbuildArgs, string[] expectedFiles)
+        {
+            // ARRANGE
+            var packageFilePath = Directory.GetFiles("packages", "*.nupkg").Single();
+            var packageId = ExtractNuGetPackage(packageFilePath);
+
+            CreateFile("Class1.cs",
+                @"
+                namespace MyNamespace
+                {
+                    public class Class1
+                    {
+                    }
+                }
+                ");
+
+            CreateFile("myproject.csproj",
+                $@"<Project Sdk=""Microsoft.NET.Sdk"">
+
+                    <Import Project=""$(MSBuildThisFileDirectory)\\{packageId}\\build\\{packageId}.props"" />
+
+                    <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                        <IsPackable>false</IsPackable>
+                        <ApiReferenceDocumentationOutputPath>api/</ApiReferenceDocumentationOutputPath>
+                        <CommandLineDocumentationOutputPath>commandlinehelp/</CommandLineDocumentationOutputPath>
+                    </PropertyGroup>
+
+                    <Import Project=""$(MSBuildThisFileDirectory)\\{packageId}\\build\\{packageId}.targets"" />
+
+                </Project>");
+
+            // ACT
+            var exitCode = RunBuild(runtime, "myproject.csproj", msbuildArgs);
+
+            // ASSERT
+            Assert.Equal(0, exitCode);
+            foreach (var file in expectedFiles)
+            {
+                Assert.True(File.Exists(Path.Combine(m_WorkingDirectory, file)));
+            }
+        }
+
+
+        private int RunBuild(MSBuildRuntimeInfo runtime, string project, string msbuildArgs)
+        {
+            return runtime.Type switch
+            {
+                MSBuildRuntimeType.Full => RunMSBuild(runtime.Version, project, msbuildArgs),
+                MSBuildRuntimeType.Core => RunDotnetBuild(runtime.Version, project, msbuildArgs),
+                _ => throw new NotImplementedException()
+            };
+        }
+
+        private void CreateFile(string name, string content)
+        {
+            var outputPath = Path.Combine(m_WorkingDirectory, name);
+            File.WriteAllText(outputPath, content);
+        }
+
+        private string ExtractNuGetPackage(string packageFilePath)
+        {
+            using var stream = File.Open(packageFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new PackageArchiveReader(stream);
+
+            var packageId = reader.GetIdentity().Id;
+
+            foreach (var file in reader.GetFiles())
+            {
+                var targetPath = Path.Combine(m_WorkingDirectory, packageId, file);
+                reader.ExtractFile(file, targetPath, NullLogger.Instance);
+            }
+
+            return packageId;
+        }
+
+        private int Exec(string fileName, string arguments)
+        {
+            var startInfo = new ProcessStartInfo()
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = m_WorkingDirectory,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            var process = Process.Start(startInfo);
+
+            process.OutputDataReceived += (s, e) => m_OutputHelper.WriteLine(e?.Data ?? "");
+            process.ErrorDataReceived += (s, e) => m_OutputHelper.WriteLine(e?.Data ?? "");
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+
+            process.WaitForExit();
+
+            process.CancelErrorRead();
+            process.CancelOutputRead();
+
+            return process.ExitCode;
+        }
+
+        private int RunMSBuild(Version msbuildVersion, string project, string args)
+        {
+            var msbuildPath = VSWhere.GetMSBuildPath(msbuildVersion.Major);
+            return Exec(msbuildPath, $"{project} {args} /restore");
+        }
+
+        private int RunDotnetBuild(Version sdkVersion, string project, string args)
+        {
+            CreateFile("global.json",
+               $@"{{
+                    ""sdk"": {{
+                        ""version"": ""{sdkVersion}""
+                    }}
+                }}");
+
+            return Exec("dotnet", $"build {project} {args}");
+        }
+    }
+}

--- a/src/MdDocs.MSBuild.IntegrationTest/MSBuildRuntimeInfo.cs
+++ b/src/MdDocs.MSBuild.IntegrationTest/MSBuildRuntimeInfo.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Xunit.Abstractions;
+
+namespace Grynwald.MdDocs.MSBuild.IntegrationTest
+{
+    public class MSBuildRuntimeInfo : IXunitSerializable
+    {
+        public MSBuildRuntimeType Type { get; private set; }
+
+        public Version Version { get; private set; }
+
+        public MSBuildRuntimeInfo(MSBuildRuntimeType runtimeType, Version version)
+        {
+            Type = runtimeType;
+            Version = version;
+        }
+
+        [Obsolete("For use by Xunit only", true)]
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public MSBuildRuntimeInfo()
+        { }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            Type = info.GetValue<MSBuildRuntimeType>(nameof(Type));
+            var versionString = info.GetValue<string>(nameof(Version));
+            Version = Version.Parse(versionString);
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue(nameof(Type), Type);
+            info.AddValue(nameof(Version), Version.ToString());
+        }
+
+
+        public override string ToString() => $"MSBuild {Type}, version {Version}";
+    }
+}

--- a/src/MdDocs.MSBuild.IntegrationTest/MSBuildRuntimeType.cs
+++ b/src/MdDocs.MSBuild.IntegrationTest/MSBuildRuntimeType.cs
@@ -1,0 +1,8 @@
+﻿namespace Grynwald.MdDocs.MSBuild.IntegrationTest
+{
+    public enum MSBuildRuntimeType
+    {
+        Core,
+        Full
+    }
+}

--- a/src/MdDocs.MSBuild.IntegrationTest/VSWhere.cs
+++ b/src/MdDocs.MSBuild.IntegrationTest/VSWhere.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Grynwald.MdDocs.MSBuild.IntegrationTest
+{
+    /// <summary>
+    /// Wrapper around vswhere.exe that enables discovery of Visual Studio installation
+    /// </summary>
+    internal static class VSWhere
+    {
+
+        private static string VSWherePath => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            @"Microsoft Visual Studio\Installer\vswhere.exe");
+
+
+        public static string GetMSBuildPath(int msbuildVersion)
+        {
+            if (msbuildVersion < 0)
+                throw new ArgumentOutOfRangeException(nameof(msbuildVersion));
+
+            var installationPath = RunVSWhere(
+                "-requires", "Microsoft.Component.MSBuild",
+                "-property", "installationPath",
+                "-version", $"[{msbuildVersion}.0, )");
+
+            installationPath = installationPath.Trim('\r', '\n');
+
+            if (String.IsNullOrEmpty(installationPath))
+                throw new VSWhereException($"Failed to locate a Visual Studio installation for version {msbuildVersion}. Installation path is empty");
+
+            if (!Directory.Exists(installationPath))
+                throw new VSWhereException($"Visual Studio installation path '{installationPath}' does not exist");
+
+
+            var msbuildPath = msbuildVersion >= 16
+                ? Path.Combine(installationPath, @"MSBuild\Current\Bin\MSBuild.exe")
+                : Path.Combine(installationPath, $@"MSBuild\{msbuildVersion}.0\Bin\MSBuild.exe");
+
+            if (!File.Exists(msbuildPath))
+                throw new VSWhereException($"Failed to locate MSBuild, '{msbuildPath}' does not exist");
+
+            return msbuildPath;
+        }
+
+
+        private static string RunVSWhere(params string[] args)
+        {
+            if (!File.Exists(VSWherePath))
+                throw new VSWhereException($"vswhere.exe not found (expected at '{VSWherePath}')");
+
+            var startInfo = new ProcessStartInfo()
+            {
+                FileName = VSWherePath,
+                Arguments = String.Join(" ", args.Select(x => $"\"{x}\"")),
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true
+            };
+
+            var stdOutBuilder = new StringBuilder();
+
+            var process = Process.Start(startInfo);
+
+            process.OutputDataReceived += (s, e) => stdOutBuilder.AppendLine(e.Data ?? "");
+
+            process.BeginOutputReadLine();
+
+            process.WaitForExit();
+            process.CancelOutputRead();
+
+            if (process.ExitCode != 0)
+                throw new VSWhereException($"vswhere.exe completed with exit code {process.ExitCode}");
+
+            return stdOutBuilder.ToString();
+        }
+    }
+}

--- a/src/MdDocs.MSBuild.IntegrationTest/VSWhereException.cs
+++ b/src/MdDocs.MSBuild.IntegrationTest/VSWhereException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Grynwald.MdDocs.MSBuild.IntegrationTest
+{
+    public class VSWhereException : Exception
+    {
+        public VSWhereException(string message) : base(message)
+        { }
+    }
+}

--- a/src/MdDocs.sln
+++ b/src/MdDocs.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grynwald.MdDocs.Test", "MdD
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grynwald.MdDocs.MSBuild.Test", "MdDocs.MSBuild.Test\Grynwald.MdDocs.MSBuild.Test.csproj", "{15EDB45F-5F29-4DE0-BA1C-F05880219224}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grynwald.MdDocs.MSBuild.IntegrationTest", "MdDocs.MSBuild.IntegrationTest\Grynwald.MdDocs.MSBuild.IntegrationTest.csproj", "{36DE9F53-7D40-4E72-846D-54F3422143E0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -206,6 +208,18 @@ Global
 		{15EDB45F-5F29-4DE0-BA1C-F05880219224}.Release|x64.Build.0 = Release|Any CPU
 		{15EDB45F-5F29-4DE0-BA1C-F05880219224}.Release|x86.ActiveCfg = Release|Any CPU
 		{15EDB45F-5F29-4DE0-BA1C-F05880219224}.Release|x86.Build.0 = Release|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Debug|x64.Build.0 = Debug|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Debug|x86.Build.0 = Debug|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Release|x64.ActiveCfg = Release|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Release|x64.Build.0 = Release|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Release|x86.ActiveCfg = Release|Any CPU
+		{36DE9F53-7D40-4E72-846D-54F3422143E0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes #75

- [x] Add tests to ensure documentation can be generated as part of a build
- [x] Fix FileNotFoundException thrown by MSBuild tasks 
  - [ ] dotnet build / MSBuild Core
  - [ ] .NET Framework MSBuild 