### PR TITLE
fix: Remove framework assembly references from Grynwald.MdDocs.MSBuild NuGet package

### DIFF
--- a/src/MdDocs.BuildVerification/PackageTest.Package_has_the_expected_content_packageId=Grynwald.MdDocs.MSBuild.verified.txt
+++ b/src/MdDocs.BuildVerification/PackageTest.Package_has_the_expected_content_packageId=Grynwald.MdDocs.MSBuild.verified.txt
@@ -3,18 +3,7 @@
   IsDevelopmentDependency: true,
   PackageTypes: [],
   Dependencies: [],
-  FrameworkReferences: [
-    {
-      TargetFramework: .NETFramework,Version=v4.7.2,
-      Assemblies: [
-        System.IO,
-        System.Runtime,
-        System.Security.Cryptography.Algorithms,
-        System.Security.Cryptography.Encoding,
-        System.Security.Cryptography.Primitives
-      ]
-    }
-  ],
+  FrameworkReferences: [],
   Files: [
     build/net472/Grynwald.MdDocs.MSBuild.pdb,
     build/netstandard2.0/Grynwald.MdDocs.MSBuild.pdb,

--- a/src/MdDocs.MSBuild/Grynwald.MdDocs.MSBuild.csproj
+++ b/src/MdDocs.MSBuild/Grynwald.MdDocs.MSBuild.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\MdDocs.CommandLineHelp\Grynwald.MdDocs.CommandLineHelp.csproj" />
     <ProjectReference Include="..\MdDocs.Common\Grynwald.MdDocs.Common.csproj" />
   </ItemGroup>
-  
+
   <!-- Adjust NuGet package properties -->
   <PropertyGroup>
     <Description>MdDocs is a tool generate documentation as markdown files. This package integrates the generation of documentation into the build process.</Description>
@@ -50,5 +50,14 @@
     </ItemGroup>
   </Target>
 
+  <!-- Remove framework references from the output NuGet package (not required for a build tools package)-->
+  <PropertyGroup>
+    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);RemoveFrameworkAssemblyReferences</GenerateNuspecDependsOn>
+  </PropertyGroup>
+  <Target Name="RemoveFrameworkAssemblyReferences">
+    <ItemGroup>
+      <_FrameworkAssemblyReferences Remove="@(_FrameworkAssemblyReferences)" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
The Grynwald.MdDocs.MSBuild package is a build tools package which does not require references to .NET Framework assemblies to be added to consuming projects
