### PR TITLE
fix: Retain blank lines from <code> blocks in the Markdown output

### DIFF
--- a/src/MdDocs.ApiReference.DemoProject/packages.lock.json
+++ b/src/MdDocs.ApiReference.DemoProject/packages.lock.json
@@ -25,8 +25,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -176,7 +176,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -185,7 +184,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -194,7 +192,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.ApiReference.Test/Model/CSharpDefinitionFormatterTest.cs
+++ b/src/MdDocs.ApiReference.Test/Model/CSharpDefinitionFormatterTest.cs
@@ -956,33 +956,39 @@ namespace Grynwald.MdDocs.ApiReference.Test.Model
 
             // ACT / ASSERT
             Assert.Equal(
-                "[Flags]\r\n" +
-                "public enum Enum1 : short\r\n" +
-                "{\r\n" +
-                "    Value1 = 0x1,\r\n" +
-                "    Value2 = 0x2,\r\n" +
-                "    Value3 = 0x4\r\n" +
-                "}\r\n",
+                """
+                [Flags]
+                public enum Enum1 : short
+                {
+                    Value1 = 0x1,
+                    Value2 = 0x2,
+                    Value3 = 0x4
+                }
+                """,
                 CSharpDefinitionFormatter.GetDefinition(enum1));
 
             Assert.Equal(
-                "[Flags]\r\n" +
-                "public enum Enum2 : short\r\n" +
-                "{\r\n" +
-                "    Value1 = 0x1,\r\n" +
-                "    Value2 = 0x2,\r\n" +
-                "    Value3 = 0x4,\r\n" +
-                "    All = 0x7\r\n" +
-                "}\r\n",
+                """
+                [Flags]
+                public enum Enum2 : short
+                {
+                    Value1 = 0x1,
+                    Value2 = 0x2,
+                    Value3 = 0x4,
+                    All = 0x7
+                }
+                """,
                 CSharpDefinitionFormatter.GetDefinition(enum2));
 
             Assert.Equal(
-                "public enum Enum3\r\n" +
-                "{\r\n" +
-                "    Value1 = 1,\r\n" +
-                "    Value2 = 2,\r\n" +
-                "    Value3 = 3\r\n" +
-                "}\r\n",
+                """
+                public enum Enum3
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3
+                }
+                """,
                 CSharpDefinitionFormatter.GetDefinition(enum3));
         }
 

--- a/src/MdDocs.ApiReference.Test/packages.lock.json
+++ b/src/MdDocs.ApiReference.Test/packages.lock.json
@@ -141,8 +141,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -1420,7 +1420,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -1429,7 +1428,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
@@ -1590,8 +1589,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -2869,7 +2868,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -2878,7 +2876,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.ApiReference/Grynwald.MdDocs.ApiReference.csproj
+++ b/src/MdDocs.ApiReference/Grynwald.MdDocs.ApiReference.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grynwald.MarkdownGenerator" Version="2.5.34" />
     <PackageReference Include="Grynwald.Utilities" Version="1.6.122" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
   </ItemGroup>

--- a/src/MdDocs.ApiReference/Model/_Helpers/CSharpDefinitionFormatter.cs
+++ b/src/MdDocs.ApiReference/Model/_Helpers/CSharpDefinitionFormatter.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Grynwald.MdDocs.Common;
-using Grynwald.Utilities.Text;
 using Mono.Cecil;
 
 namespace Grynwald.MdDocs.ApiReference.Model
@@ -528,7 +527,7 @@ namespace Grynwald.MdDocs.ApiReference.Model
                 type.GetEnumValues().Select(x => $"    {x.name} = {(isFlagsEnum ? "0x" + x.value.ToString("X") : x.value.ToString())}")
             );
             definitionBuilder.AppendLine();
-            definitionBuilder.AppendLine("}");
+            definitionBuilder.Append("}");
         }
 
         private static string GetOperatorString(OperatorKind kind)

--- a/src/MdDocs.ApiReference/packages.lock.json
+++ b/src/MdDocs.ApiReference/packages.lock.json
@@ -2,12 +2,6 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
-      "Grynwald.MarkdownGenerator": {
-        "type": "Direct",
-        "requested": "[2.5.34, )",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
-      },
       "Grynwald.Utilities": {
         "type": "Direct",
         "requested": "[1.6.122, )",
@@ -41,6 +35,11 @@
         "requested": "[3.5.119, )",
         "resolved": "3.5.119",
         "contentHash": "x8k4zV6YKZA5Rr810439lG9NngdbyPtFv0QpIYz32m1Im59kvSbEHO8gKGZoNvsfZSquayjEDUCa8acbut372g=="
+      },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Transitive",
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -162,7 +161,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
@@ -172,12 +171,6 @@
       }
     },
     "net7.0": {
-      "Grynwald.MarkdownGenerator": {
-        "type": "Direct",
-        "requested": "[2.5.34, )",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
-      },
       "Grynwald.Utilities": {
         "type": "Direct",
         "requested": "[1.6.122, )",
@@ -211,6 +204,11 @@
         "requested": "[3.5.119, )",
         "resolved": "3.5.119",
         "contentHash": "x8k4zV6YKZA5Rr810439lG9NngdbyPtFv0QpIYz32m1Im59kvSbEHO8gKGZoNvsfZSquayjEDUCa8acbut372g=="
+      },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Transitive",
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -332,7 +330,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.CommandLineHelp.DemoProject/packages.lock.json
+++ b/src/MdDocs.CommandLineHelp.DemoProject/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -177,7 +177,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -186,7 +185,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -195,7 +193,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.CommandLineHelp.Test/packages.lock.json
+++ b/src/MdDocs.CommandLineHelp.Test/packages.lock.json
@@ -124,8 +124,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -1403,7 +1403,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -1412,7 +1411,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
@@ -1556,8 +1555,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -2835,7 +2834,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -2844,7 +2842,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.CommandLineHelp/Grynwald.MdDocs.CommandLineHelp.csproj
+++ b/src/MdDocs.CommandLineHelp/Grynwald.MdDocs.CommandLineHelp.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grynwald.MarkdownGenerator" Version="2.5.34" />
     <PackageReference Include="Grynwald.Utilities" Version="1.6.122" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
   </ItemGroup>

--- a/src/MdDocs.CommandLineHelp/packages.lock.json
+++ b/src/MdDocs.CommandLineHelp/packages.lock.json
@@ -2,12 +2,6 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
-      "Grynwald.MarkdownGenerator": {
-        "type": "Direct",
-        "requested": "[2.5.34, )",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
-      },
       "Grynwald.Utilities": {
         "type": "Direct",
         "requested": "[1.6.122, )",
@@ -41,6 +35,11 @@
         "requested": "[3.5.119, )",
         "resolved": "3.5.119",
         "contentHash": "x8k4zV6YKZA5Rr810439lG9NngdbyPtFv0QpIYz32m1Im59kvSbEHO8gKGZoNvsfZSquayjEDUCa8acbut372g=="
+      },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Transitive",
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -162,7 +161,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
@@ -172,12 +171,6 @@
       }
     },
     "net7.0": {
-      "Grynwald.MarkdownGenerator": {
-        "type": "Direct",
-        "requested": "[2.5.34, )",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
-      },
       "Grynwald.Utilities": {
         "type": "Direct",
         "requested": "[1.6.122, )",
@@ -211,6 +204,11 @@
         "requested": "[3.5.119, )",
         "resolved": "3.5.119",
         "contentHash": "x8k4zV6YKZA5Rr810439lG9NngdbyPtFv0QpIYz32m1Im59kvSbEHO8gKGZoNvsfZSquayjEDUCa8acbut372g=="
+      },
+      "Grynwald.MarkdownGenerator": {
+        "type": "Transitive",
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -332,7 +330,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.Common.Test/packages.lock.json
+++ b/src/MdDocs.Common.Test/packages.lock.json
@@ -140,8 +140,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -1419,7 +1419,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
@@ -1579,8 +1579,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -2858,7 +2858,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.Common/Grynwald.MdDocs.Common.csproj
+++ b/src/MdDocs.Common/Grynwald.MdDocs.Common.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grynwald.MarkdownGenerator" Version="2.5.34" />
+    <PackageReference Include="Grynwald.MarkdownGenerator" Version="3.0.106" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/src/MdDocs.Common/packages.lock.json
+++ b/src/MdDocs.Common/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "Grynwald.MarkdownGenerator": {
         "type": "Direct",
-        "requested": "[2.5.34, )",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "requested": "[3.0.106, )",
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.DotNet.Analyzers.Compatibility": {
         "type": "Direct",
@@ -161,9 +161,9 @@
     "net7.0": {
       "Grynwald.MarkdownGenerator": {
         "type": "Direct",
-        "requested": "[2.5.34, )",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "requested": "[3.0.106, )",
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Microsoft.DotNet.Analyzers.Compatibility": {
         "type": "Direct",

--- a/src/MdDocs.MSBuild.IntegrationTest/packages.lock.json
+++ b/src/MdDocs.MSBuild.IntegrationTest/packages.lock.json
@@ -132,8 +132,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -1551,7 +1551,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -1560,7 +1559,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -1569,7 +1567,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.MSBuild/packages.lock.json
+++ b/src/MdDocs.MSBuild/packages.lock.json
@@ -37,8 +37,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -188,7 +188,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -197,7 +196,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -206,7 +204,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs.Test/packages.lock.json
+++ b/src/MdDocs.Test/packages.lock.json
@@ -96,8 +96,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities.Logging": {
         "type": "Transitive",
@@ -1228,7 +1228,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -1237,7 +1236,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -1246,7 +1244,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
@@ -1350,8 +1348,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities.Logging": {
         "type": "Transitive",
@@ -2482,7 +2480,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -2491,7 +2488,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -2500,7 +2496,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",

--- a/src/MdDocs/packages.lock.json
+++ b/src/MdDocs/packages.lock.json
@@ -41,8 +41,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -174,7 +174,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -183,7 +182,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -192,7 +190,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",
@@ -241,8 +239,8 @@
       },
       "Grynwald.MarkdownGenerator": {
         "type": "Transitive",
-        "resolved": "2.5.34",
-        "contentHash": "2esww+F8jCv2bfFkQJ7lAUfk7adbjI70i4cXdsd6TQIKIUIVgLNbLw0sZuvjbXpRfjrKu3nOTYiehS5Ua1l0Mw=="
+        "resolved": "3.0.106",
+        "contentHash": "rwpMqWHIrgnFdwpSE9HtDvBUjxqX+nNC0qsWtrQvJm6F8Jv/j6Id5eCuLVLWcGozPD6zkrIO94EMlc4zeCinLA=="
       },
       "Grynwald.Utilities": {
         "type": "Transitive",
@@ -374,7 +372,6 @@
       "grynwald.mddocs.apireference": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -383,7 +380,6 @@
       "grynwald.mddocs.commandlinehelp": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
           "Grynwald.MdDocs.Common": "[1.0.0, )",
           "Grynwald.Utilities": "[1.6.122, )",
           "Mono.Cecil": "[0.11.4, )"
@@ -392,7 +388,7 @@
       "grynwald.mddocs.common": {
         "type": "Project",
         "dependencies": {
-          "Grynwald.MarkdownGenerator": "[2.5.34, )",
+          "Grynwald.MarkdownGenerator": "[3.0.106, )",
           "Microsoft.Extensions.Configuration": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Binder": "[6.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[6.0.0, )",


### PR DESCRIPTION
Update dependency Grynwald.MarkdownGenerator to version 3.0.106 which includes a fix for serialization of Markdown code blocks (all blank lines from code blocks used to be removed from the output).


See: #245 